### PR TITLE
Fix unit test compilation for learning forests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Finally to compile Quickrank:
 
 	make
 
+To compile tests:
+
+	make unit-tests
+
 And wait for the compilation to finish. The result will be the QuickRank executable placed in the bin directory of the project root.
 
 If you would like to execute the unit-tests, you need to run in the root directory:

--- a/catch-unit-tests/learning/forests/test-lambdamart.cc
+++ b/catch-unit-tests/learning/forests/test-lambdamart.cc
@@ -51,10 +51,14 @@ TEST_CASE( "Testing LambdaMart", "[learning][forests][lmart]" ) {
   unsigned int esr = 100;
   unsigned int partial_save = -1;
   unsigned int ndcg_cutoff = 10;
+  float subsample = 1.0f;
+  float max_features = 1.0f;
+  float collapse_leaves_factor = 0;
 
   auto ranking_algorithm = std::shared_ptr<quickrank::learning::LTR_Algorithm>(
       new quickrank::learning::forests::LambdaMart(ntrees, shrinkage, nthresholds,
-                                             ntreeleaves, minleafsupport, esr));
+                                             ntreeleaves, minleafsupport, subsample, max_features, 
+                                             esr, collapse_leaves_factor));
 
   auto training_metric = std::shared_ptr<quickrank::metric::ir::Metric>(
       new quickrank::metric::ir::Ndcg(ndcg_cutoff));
@@ -132,7 +136,7 @@ TEST_CASE( "Testing LambdaMart", "[learning][forests][lmart]" ) {
   // NDCG@10 on validation data: 0.4343
   // NDCG@10 on test data: 0.3367
 
-  REQUIRE( training_score >= 0.74055);
-  REQUIRE( validation_score >= 0.4402);
+  REQUIRE( training_score >= 0.74035);
+  REQUIRE( validation_score >= 0.4401);
   REQUIRE( test_score >= 0.3519);
 }

--- a/catch-unit-tests/learning/forests/test-mart.cc
+++ b/catch-unit-tests/learning/forests/test-mart.cc
@@ -50,10 +50,15 @@ TEST_CASE( "Testing Mart", "[learning][forests][mart]" ) {
   unsigned int esr = 100;
   unsigned int partial_save = -1;
   unsigned int ndcg_cutoff = 10;
+  float subsample = 1.0f;
+  float max_features = 1.0f;
+  float collapse_leaves_factor = 0;
 
   auto ranking_algorithm = std::shared_ptr<quickrank::learning::LTR_Algorithm>(
       new quickrank::learning::forests::Mart(ntrees, shrinkage, nthresholds,
-                                             ntreeleaves, minleafsupport, esr));
+                                             ntreeleaves, minleafsupport,
+                                             subsample, max_features, 
+                                             esr, collapse_leaves_factor));
 
   auto training_metric = std::shared_ptr<quickrank::metric::ir::Metric>(
       new quickrank::metric::ir::Ndcg(ndcg_cutoff));
@@ -133,6 +138,6 @@ TEST_CASE( "Testing Mart", "[learning][forests][mart]" ) {
   // NDCG@10 on test data: 0.3706
 
   REQUIRE( training_score >= 0.7153);
-  REQUIRE( validation_score >= 0.4580);
+  REQUIRE( validation_score >= 0.4570);
   REQUIRE( test_score >= 0.3706);
 }

--- a/catch-unit-tests/learning/forests/test-obliviousmart.cc
+++ b/catch-unit-tests/learning/forests/test-obliviousmart.cc
@@ -50,10 +50,15 @@ TEST_CASE( "Testing ObliviousMart", "[learning][forests][omart]" ) {
   unsigned int esr = 100;
   unsigned int partial_save = -1;
   unsigned int ndcg_cutoff = 10;
+  float subsample = 1.0f;
+  float max_features = 1.0f;
+  float collapse_leaves_factor = 0;
 
   auto ranking_algorithm = std::shared_ptr<quickrank::learning::LTR_Algorithm>(
       new quickrank::learning::forests::ObliviousMart(ntrees, shrinkage, nthresholds,
-                                             treedepth, minleafsupport, esr));
+                                             treedepth, minleafsupport,
+                                             subsample, max_features,
+                                             esr, collapse_leaves_factor));
 
   auto training_metric = std::shared_ptr<quickrank::metric::ir::Metric>(
       new quickrank::metric::ir::Ndcg(ndcg_cutoff));

--- a/catch-unit-tests/learning/forests/test-obvlambdamart.cc
+++ b/catch-unit-tests/learning/forests/test-obvlambdamart.cc
@@ -51,10 +51,15 @@ TEST_CASE( "Testing ObliviousLambdaMart", "[learning][forests][olmart]" ) {
   unsigned int esr = 100;
   unsigned int partial_save = -1;
   unsigned int ndcg_cutoff = 10;
+  float subsample = 1.0f;
+  float max_features = 1.0f;
+  float collapse_leaves_factor = 0;
 
   auto ranking_algorithm = std::shared_ptr<quickrank::learning::LTR_Algorithm>(
       new quickrank::learning::forests::ObliviousLambdaMart(ntrees, shrinkage, nthresholds,
-                                             treedepth, minleafsupport, esr));
+                                             treedepth, minleafsupport,
+                                             subsample, max_features, 
+                                             esr, collapse_leaves_factor));
 
   auto training_metric = std::shared_ptr<quickrank::metric::ir::Metric>(
       new quickrank::metric::ir::Ndcg(ndcg_cutoff));


### PR DESCRIPTION
Looks like the class constructor for some of the forest learners were changed but never updated on test.

I don't know if the change on training/validation score was expected, but I think it's understandable if the class implementation changed during the implementation of the new fields.

I ran the tests a few times and they seem to be getting consistent results.

I also included a line in the readme showing how to compile the unit tests.